### PR TITLE
use the relative coffin in compiling

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -47,7 +47,7 @@
 
   compileTemplate = function(source, params, callback) {
     var pre;
-    pre = "require('coffin') ->\n";
+    pre = "require('../lib/coffin') ->\n";
     return fs.readFile(source, function(err, code) {
       var compiled, line, tabbedLines, template, templateString, _i, _len, _ref1;
       if (err) {

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -25,7 +25,7 @@ validateArgs = ->
     process.exit 0
 
 compileTemplate = (source, params, callback) =>
-  pre = "require('coffin') ->\n"
+  pre = "require('../lib/coffin') ->\n"
   fs.readFile source, (err, code) =>
     if err
       console.error "#{source} not found"


### PR DESCRIPTION
We can use a relative ../lib/coffin so coffin doesn't have to be installed locally for the compile command to succeed.

This shouldn't break anything but let me know if you have issues 
