### PR TITLE
fix the region and stack to properly use a ref

### DIFF
--- a/lib/coffin.js
+++ b/lib/coffin.js
@@ -269,9 +269,13 @@
       };
     };
 
-    CloudFormationTemplateContext.prototype.Region = 'AWS::Region';
+    CloudFormationTemplateContext.prototype.Region = {
+      Ref: 'AWS::Region'
+    };
 
-    CloudFormationTemplateContext.prototype.StackName = 'AWS::StackName';
+    CloudFormationTemplateContext.prototype.StackName = {
+      Ref: 'AWS::StackName'
+    };
 
     CloudFormationTemplateContext.prototype.InitScript = function(arg) {
       var chunks, compiled, match, pattern, text;

--- a/src/coffin.coffee
+++ b/src/coffin.coffee
@@ -150,8 +150,8 @@ class CloudFormationTemplateContext
     'Fn::Base64': arg
   GetAZs: (arg) ->
     'Fn::GetAZs': arg
-  Region: 'AWS::Region'
-  StackName: 'AWS::StackName'
+  Region: Ref: 'AWS::Region'
+  StackName: Ref: 'AWS::StackName'
   InitScript: (arg) ->
     if not path.existsSync(arg)
       text = arg


### PR DESCRIPTION
@Region and @StackName currently don't produce valid CloudFormation syntax as they don't use "Ref".

This should fix that.
